### PR TITLE
Fixes quest description bug

### DIFF
--- a/quests.js
+++ b/quests.js
@@ -97,7 +97,7 @@ function addQuestDescription(questSheet, questDescription) {
 
 function getQuestDescription(quests, { id }) {
     const [, questNum] = id.split('-');
-    const questDescription = quests[questNum].description;
+    const questDescription = quests[(questNum-1)].description;
     return questDescription;
 }
 


### PR DESCRIPTION
The wrong quest description was being inserted in the quest sheet. The id was being used as an index and started at 1 instead of 0. Subtracted 1 from the index to get the correct array position and the right description.