### PR TITLE
Remove stored quest on status of not started

### DIFF
--- a/quests.js
+++ b/quests.js
@@ -68,6 +68,7 @@ function updateQuest(quests, questSheet, questStatus) {
     switch (questStatus) {
         case 'not-started':
             removeQuestHeroesAndDescriptions(questSheet);
+            deleteQuest(questSheet);
             break;
         case 'current-quest':
             removeQuestHeroesAndDescriptions(questSheet);

--- a/storage.js
+++ b/storage.js
@@ -38,3 +38,10 @@ function storeQuest(quest, heroes) {
     }
     localStorage.setItem('storedQuests', JSON.stringify(storedQuests));
 }
+
+function deleteQuest(quest) {
+    const storedQuests = JSON.parse(localStorage.getItem('storedQuests'));
+    const index = storedQuests.findIndex(storedQuest => storedQuest.id === quest.id);
+    storedQuests.splice(index, 1);
+    localStorage.setItem('storedQuests', JSON.stringify(storedQuests));
+}


### PR DESCRIPTION
Remove a stored quest when the status is changed to not started to allow the quest to be restarted.