### PR TITLE
Grey out not started quests

### DIFF
--- a/quests.js
+++ b/quests.js
@@ -93,7 +93,7 @@ function displayQuestList() {
         const listLi = document.createElement('li');
         listLi.setAttribute('class', 'quest-list-item');
         listLi.textContent = `Quest ${quest.id}`;
-        listLi.setAttribute('class', 'not-started');
+        setAttributes(listLi, {class: 'not-started', id: `quest-${quest.id}`});
         questList.appendChild(listLi);
     })
 }
@@ -125,6 +125,7 @@ function updateQuest(quests, questSheet, questStatus) {
                 const quest = getQuest(quests, questSheet);
                 addQuestDescription(questSheet, quest.description);
                 addHeroOptions(questSheet);
+                removeNotStartedClass(questSheet);
             }
             break;
         case 'complete':
@@ -334,6 +335,13 @@ function updateQuestStatus(quest, storedQuest) {
     } else {
         status[0].value = 'not-started';
     }
+}
+
+function removeNotStartedClass({ id }) {
+    const array = id.split('-');
+    const questId = `${array[0]}-${array[1]}`;
+    const quest = document.getElementById(questId);
+    quest.classList.remove('not-started');
 }
 
 displayQuests();

--- a/quests.js
+++ b/quests.js
@@ -93,6 +93,7 @@ function displayQuestList() {
         const listLi = document.createElement('li');
         listLi.setAttribute('class', 'quest-list-item');
         listLi.textContent = `Quest ${quest.id}`;
+        listLi.setAttribute('class', 'not-started');
         questList.appendChild(listLi);
     })
 }
@@ -130,7 +131,8 @@ function updateQuest(quests, questSheet, questStatus) {
             if (storedQuest) {
                 addCompletedHeroOptions(questSheet);
                 removeQuestHeroesAndDescriptions(questSheet);
-                displayNextQuest(questSheet);    
+                displayNextQuest(questSheet); 
+
             } else {
                 alert('Slow your roll. You mush start a quest before you can complete it.');
                 updateQuestStatus(questSheet, storedQuest);

--- a/quests.js
+++ b/quests.js
@@ -77,11 +77,14 @@ function displayQuests() {
                     addQuestDescription(questSheet, currentQuest.description);
                     addCurrentQuestHeroes(questSheet, storedQuest.heroes);
                     updateQuestStatus(questSheet, storedQuest);
-                    break;
+                break;
                 case 'complete':
                     addCompletedQuestHeroes(questSheet, storedQuest.heroes);
                     updateQuestStatus(questSheet, storedQuest);
-                    break;    
+                    if (quest.id === (storedQuests.length)) {
+                        displayNextQuest(questSheet);
+                    }                        
+                break;    
             }
         })    
     }
@@ -91,9 +94,13 @@ function displayQuestList() {
     const questList = document.getElementById('quest-list');
     quests.forEach(quest => {
         const listLi = document.createElement('li');
-        listLi.setAttribute('class', 'quest-list-item');
+        listLi.setAttribute('id', `quest-${quest.id}`);
         listLi.textContent = `Quest ${quest.id}`;
-        setAttributes(listLi, {class: 'not-started', id: `quest-${quest.id}`});
+        if (getStoredQuest(quest)) {
+            listLi.setAttribute('class', `list-item`);
+        } else {
+            listLi.setAttribute('class', 'list-item not-started');
+        }
         questList.appendChild(listLi);
     })
 }
@@ -133,7 +140,6 @@ function updateQuest(quests, questSheet, questStatus) {
                 addCompletedHeroOptions(questSheet);
                 removeQuestHeroesAndDescriptions(questSheet);
                 displayNextQuest(questSheet); 
-
             } else {
                 alert('Slow your roll. You mush start a quest before you can complete it.');
                 updateQuestStatus(questSheet, storedQuest);

--- a/styles.css
+++ b/styles.css
@@ -126,3 +126,7 @@ header ul {
 .show {
     display: flex;
 }
+
+.not-started {
+    color: silver;
+}


### PR DESCRIPTION
Adds light grey style to quest list text for quests that haven't been started and making them dark when the quest has been started. Also, displays next quest sheet if the last stored quest has been completed to allow the user to start the next quest.