### PR TITLE
Prevent equipping multiple items

### DIFF
--- a/app.js
+++ b/app.js
@@ -627,6 +627,7 @@ function createEquipOrUnequipItemBtn(characterId, itemName) {
             } else {
                 alert('You much unequip your existing item before you can equip another one in the same location');
                 modal.close();
+                clearModal(modal);
             }
         });
         

--- a/app.js
+++ b/app.js
@@ -540,7 +540,7 @@ function createItemModal(itemName, characterId) {
     const itemCard = createItemCard(itemName);
     modal.appendChild(itemCard);
 
-    const equipOrUnequipBtn = createEquipOrUnequipItemBtn(characterId, itemName);
+    const equipOrUnequipBtn = createEquipOrUnequipItemBtn(characterId, item);
     modal.appendChild(equipOrUnequipBtn);
 
     modal.showModal();
@@ -608,15 +608,14 @@ function createCharacterItemsList(nodeList) {
     return characterList;
 }
 
-function createEquipOrUnequipItemBtn(characterId, itemName) {
-    const item = findItemWithName(itemName);
+function createEquipOrUnequipItemBtn(characterId, item) {
     const currentCharacter = getStoredCharacter(characterId);
     const equippedItem = currentCharacter?.equippedItems?.find(equippedItem => equippedItem.id === item.id); 
 
     if (!equippedItem && !isEquippedItemDisplayed(characterId, item)) {
         const equipItemBtn = document.createElement('button');
         // Is this ID being utilized? Remove if not
-        equipItemBtn.setAttribute('id', `character-${characterId}-equip-${itemName}`);
+        equipItemBtn.setAttribute('id', `character-${characterId}-equip-${item.name}`);
         equipItemBtn.textContent = 'Equip';
     
         equipItemBtn.addEventListener('click', () => {
@@ -634,7 +633,7 @@ function createEquipOrUnequipItemBtn(characterId, itemName) {
         return equipItemBtn;
     } else {
         const unequipItemBtn = document.createElement('button');
-        unequipItemBtn.setAttribute('id', `character-${characterId}-unequip-${itemName}`);
+        unequipItemBtn.setAttribute('id', `character-${characterId}-unequip-${item.name}`);
         unequipItemBtn.textContent = 'Unequip';
 
         unequipItemBtn.addEventListener('click', () => {
@@ -742,7 +741,7 @@ function equipItem(characterId, item) {
         case 'body':
             const bodyContainer = document.getElementById(`character-${characterId}-body-container`);
             const bodyItemImage = createItemImage(item, characterId);
-            body.addEventListener('click', () => {
+            bodyItemImage.addEventListener('click', () => {
                 createItemModal(item.name, characterId);
             });
             bodyContainer.appendChild(bodyItemImage);
@@ -838,7 +837,7 @@ function isEquippedItemDisplayed(characterId, item) {
 
 function checkIfEquippedLocationTaken(characterId, item) {
     const containerToCheck = document.getElementById(`character-${characterId}-${item.equippedLocation}-container`);
-    return containerToCheck.querySelector('.item-image');
+    return containerToCheck?.querySelector('.item-image');
 }
 
 function removeItem(itemsList, itemId) {

--- a/app.js
+++ b/app.js
@@ -620,9 +620,14 @@ function createEquipOrUnequipItemBtn(characterId, itemName) {
         equipItemBtn.textContent = 'Equip';
     
         equipItemBtn.addEventListener('click', () => {
-            equipItem(characterId, item);
-            modal.close();
-            clearModal(modal);
+            if (!checkIfEquippedLocationTaken(characterId, item)) {
+                equipItem(characterId, item);
+                modal.close();
+                clearModal(modal);    
+            } else {
+                alert('You much unequip your existing item before you can equip another one in the same location');
+                modal.close();
+            }
         });
         
         return equipItemBtn;
@@ -828,6 +833,11 @@ function isEquippedItemDisplayed(characterId, item) {
     const equippedItemContainer = document.getElementById(`character-${characterId}-${item.equippedLocation}-container`);
     const foundItem = equippedItemContainer?.querySelector(`#character-${characterId}-${item.id}`);
     return foundItem ? true : false;
+}
+
+function checkIfEquippedLocationTaken(characterId, item) {
+    const containerToCheck = document.getElementById(`character-${characterId}-${item.equippedLocation}-container`);
+    return containerToCheck.querySelector('.item-image');
 }
 
 function removeItem(itemsList, itemId) {


### PR DESCRIPTION
Checks if an item is already equpped in the location the selected item belongs , and if so, it displays the message to unequip the item before equipping the current item.