### PR TITLE
Equipping extra items

### DIFF
--- a/app.js
+++ b/app.js
@@ -665,13 +665,26 @@ function createEquipOrUnequipItemBtn(characterId, item) {
 
     } else if (!item.equippedLocation) {
         const consumeItemBtn = document.createElement('button');
-        consumeItemBtn.textContent = 'Use';
+
+        switch (item.name) {
+            case 'Holy Water':
+                consumeItemBtn.textContent = 'Use';
+                break;
+            case 'Tool Kit':
+                consumeItemBtn.textContent = 'Disarm a Trap';
+                break;
+            case 'Rod of Telekinesis':
+                consumeItemBtn.textContent = 'Use';
+                break;
+            default:
+                consumeItemBtn.textContent = 'Consume';
+        }
+
+        // item.name === 'Holy Water' ? consumeItemBtn.textContent = 'Use' : consumeItemBtn.textContent = 'Consume';
 
         consumeItemBtn.addEventListener('click', () => {
             const characterConsumedItem = document.getElementById(`character-${characterId}-${item.id}`).parentNode;
             characterConsumedItem.remove();
-            // Remove item from character
-            // Check weapons and armor, and potions ond items 
             if (currentCharacter.weaponsAndArmor.find(weaponsArmorItem => weaponsArmorItem === item.name)) {
                 currentCharacter.weaponsAndArmor.pop(item.name);
             } else if (currentCharacter.potionsAndItems.find(potionOrItem => potionOrItem === item.name)) {

--- a/app.js
+++ b/app.js
@@ -796,6 +796,11 @@ function equipItem(characterId, item) {
         return;
     }
 
+    if (item.equippedLocation === 'extra' && !isExtraItemContainerAvailable(characterId, item)) {
+        alert(`${item.name} can\'t be equipped. Please unequip one of your extra items to equip ${item.name}.`);
+        return;
+    }
+
     switch (item.equippedLocation) {
         case 'head':
             const headContainer = document.getElementById(`character-${characterId}-head-container`);
@@ -912,9 +917,6 @@ function isCurrentCharacter(characters, { characterId }) {
 }
 
 function isEquippedItemDisplayed(characterId, item) {
-    // If item.equippedLocation = 'extra'
-    // extraContainer1
-    // extraContainer1 contain item
     if (item.equippedLocation === 'extra') {
         const extraLocation1 = document.getElementById(`character-${characterId}-extra-1-container`);
         const extraLocation2 = document.getElementById(`character-${characterId}-extra-2-container`);
@@ -933,6 +935,17 @@ function isEquippedItemDisplayed(characterId, item) {
 function checkIfEquippedLocationTaken(characterId, item) {
     const containerToCheck = document.getElementById(`character-${characterId}-${item.equippedLocation}-container`);
     return containerToCheck?.querySelector('.item-image');
+}
+
+function isExtraItemContainerAvailable(characterId, item) {
+    const extra1Container = document.getElementById(`character-${characterId}-extra-1-container`);
+    const extra2Container = document.getElementById(`character-${characterId}-extra-2-container`);
+
+    if (extra1Container.hasChildNodes() && extra2Container.hasChildNodes()) {
+        return false;
+    } else {
+        return true;
+    }
 }
 
 function removeItem(itemsList, itemId) {

--- a/app.js
+++ b/app.js
@@ -912,9 +912,22 @@ function isCurrentCharacter(characters, { characterId }) {
 }
 
 function isEquippedItemDisplayed(characterId, item) {
-    const equippedItemContainer = document.getElementById(`character-${characterId}-${item.equippedLocation}-container`);
-    const foundItem = equippedItemContainer?.querySelector(`#character-${characterId}-${item.id}`);
-    return foundItem ? true : false;
+    // If item.equippedLocation = 'extra'
+    // extraContainer1
+    // extraContainer1 contain item
+    if (item.equippedLocation === 'extra') {
+        const extraLocation1 = document.getElementById(`character-${characterId}-extra-1-container`);
+        const extraLocation2 = document.getElementById(`character-${characterId}-extra-2-container`);
+
+        const foundItemInLocation1 = extraLocation1.querySelector(`#character-${characterId}-${item.id}`);
+        const foundItemInLocation2 = extraLocation2.querySelector(`#character-${characterId}-${item.id}`);
+
+        return foundItemInLocation1 || foundItemInLocation2 ? true : false;
+    } else {
+        const equippedItemContainer = document.getElementById(`character-${characterId}-${item.equippedLocation}-container`);
+        foundItem = equippedItemContainer?.querySelector(`#character-${characterId}-${item.id}`); 
+        return foundItem ? true : false;   
+    }
 }
 
 function checkIfEquippedLocationTaken(characterId, item) {

--- a/data.js
+++ b/data.js
@@ -186,7 +186,7 @@ const items = [
         type: 'artifact',
         image: 'item-spell-ring-132x100.png',
         imageDescription: 'A wizard\'s hand with a thick ring holding a spell book',
-        itemLocation: 'extra'
+        equippedLocation: 'extra'
     },
     {
         id: 'talisman-of-lore',


### PR DESCRIPTION
Equipping extra items will now take into account if the item is already equipped, and if so the user will be provided with the unequip button on the item card instead of equip. Also, accounts for the user trying to equip more than 2 items and will alert the user if they try to do so that their item can't be equipped unless another item is unequipped.