### PR TITLE
Incompatible items UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -612,6 +612,8 @@ function checkItemCompatibility(characterId, item) {
     if (item.incompatibilities?.includes(characterType) || item.incompatibilities?.some(incompatibility => equippedItemsById.includes(incompatibility))) {
         const element = document.getElementById(`character-${characterId}-${item.id}`);
         element.classList.add('incompatible');
+        const incompatibleMessage = createIncompatibleItemMessageBox(item);
+        element.after(incompatibleMessage);
         return 'incompatible';
     }
 }
@@ -629,6 +631,8 @@ function checkItemsCompatibility(characterId, itemsByName) {
             const element = document.getElementById(`character-${characterId}-${item.id}`);
             element.classList.add('incompatible');
             incompatibleItems.push(item);
+            const incompatibleMessage = createIncompatibleItemMessageBox(item);
+            element.after(incompatibleMessage);
         }
     })
 }
@@ -728,6 +732,19 @@ function createEquippedItemContainer(equippedItemLocation, playerId) {
     equippedItemContainer.setAttribute('id', `character-${playerId}-${equippedItemLocation}-container`);
     equippedItemContainer.setAttribute('class', `equipped-${equippedItemLocation}-item`);
     return equippedItemContainer;
+}
+
+function createIncompatibleItemMessageBox(item) {
+    const messageBox = document.createElement('div');
+    messageBox.setAttribute('class', 'incompatible-message');
+    messageBox.setAttribute('class', 'hide');
+
+    const message = document.createElement('p');
+    message.textContent = `${item.name} can't be equipped. Please read the ${item.name} card for why.`;
+    
+    messageBox.appendChild(message);
+
+    return messageBox;
 }
 
 function createItemCard(item) {

--- a/app.js
+++ b/app.js
@@ -644,7 +644,9 @@ function createCharacterItemsList(nodeList) {
     nodeList.forEach(li => {
         const itemId = li.dataset.characterItemId;
         const foundItem = findItemWithId(itemId);
-        characterItems.push(foundItem);
+        if (foundItem) {
+            characterItems.push(foundItem);
+        }
     });
     return characterItems;
 }

--- a/app.js
+++ b/app.js
@@ -648,8 +648,12 @@ function checkCharacterItemsCompatibility(characterId) {
             const incompatibleMessage = createIncompatibleItemMessageBox(item);
             element.after(incompatibleMessage);
         } else {
-            if (!equippedItems.includes(item) && incompatibleItems.indexOf(item) != -1){
+            if (!equippedItems.includes(item)){
                 element.classList.remove('incompatible');
+
+            }
+
+            if (incompatibleItems.indexOf(item) != -1) {
                 incompatibleItems.splice(incompatibleItems.indexOf(item), 1);  
             }
         }
@@ -735,6 +739,7 @@ function createEquipUnequipOrConsumeBtn(characterId, item) {
             unequipItem(characterId, item);
             modal.close();
             clearModal(modal);
+            checkCharacterItemsCompatibility(characterId);
         });
 
         return unequipItemBtn;
@@ -862,6 +867,7 @@ function equipItem(characterId, item) {
                 createItemModal(item.name, characterId);
             });
             bodyContainer.appendChild(bodyItemImage);
+            storeEquippedItemToCharacter(characterId, item);
             break;
         case 'left-hand':
             const leftHandContainer = document.getElementById(`character-${characterId}-left-hand-container`);
@@ -870,6 +876,7 @@ function equipItem(characterId, item) {
                 createItemModal(item.name, characterId);
             });
             leftHandContainer.appendChild(leftHandItemImage);
+            storeEquippedItemToCharacter(characterId, item);
             break;
         case 'right-hand':
             const rightHandContainer = document.getElementById(`character-${characterId}-right-hand-container`);
@@ -878,6 +885,7 @@ function equipItem(characterId, item) {
                 createItemModal(item.name, characterId);
             });
             rightHandContainer.appendChild(rightHandItemImage);
+            storeEquippedItemToCharacter(characterId, item);
             break;
         case 'extra':
             if (!document.querySelector(`#character-${characterId}-extra-1-container img`)) {

--- a/app.js
+++ b/app.js
@@ -251,10 +251,10 @@ const characterSheet = (character) => {
         const defDiceSel = document.getElementById(getDefendDice(characterId));
         const startBodyPtsInput = document.getElementById(getStartBodyPoints(characterId));
         const startMindPtsInput = document.getElementById(getStartMindPoints(characterId));
-        const weaponsAndArmorList = document. getElementById(getWeaponsAndArmor(characterId)).querySelectorAll('li');
+        const weaponsAndArmorList = document. getElementById(getWeaponsAndArmor(characterId)).querySelectorAll('.equippable-item');
         const curBodyPtsInput = document.getElementById(getCurrentBodyPoints(characterId));
         const curGoldCoins = document.getElementById(getCurrentGoldCoins(characterId));
-        const potionsItemsList = document.getElementById(getPotionsAndItems(characterId)).querySelectorAll('li');
+        const potionsItemsList = document.getElementById(getPotionsAndItems(characterId)).querySelectorAll('.equippable-item');
         const nameInput = document.getElementById(getCharacterName(characterId));
         const equippedItemsImages = document.getElementById(getEquippedItems(uniqueId)).querySelectorAll('.item-image');
 
@@ -553,7 +553,7 @@ function addCharacter(character) {
 
 function addItemToCharacterList(characterId, list, item) {
     const li = document.createElement('li');
-    li.setAttribute('value', (item.id));
+    li.setAttribute('data-character-item-id', (item.id));
     
     const itemSpan = document.createElement('span');
     itemSpan.setAttribute('class', 'equippable-item');
@@ -607,11 +607,12 @@ function characterDeath(event, characters, character) {
 function checkItemCompatibility(characterId, item) {
     const characterType = document.getElementById(`character-${characterId}-type`).value;
     const equippedItems = getCharacterEquippedItems(characterId);
-    const equippedItemsById = equippedItems.map(equippedItem => equippedItem.id);
+    const equippedItemsById = equippedItems?.map(equippedItem => equippedItem.id);
 
-    if (item.incompatibilities?.includes(characterType) || item.incompatibilities?.some(incompatibility => equippedItemsById.includes(incompatibility))) {
+    if (item.incompatibilities?.includes(characterType) || item.incompatibilities?.some(incompatibility => equippedItemsById?.includes(incompatibility))) {
         const element = document.getElementById(`character-${characterId}-${item.id}`);
         element.classList.add('incompatible');
+        // element.setAttribute('data-hover', `${item.name} can't be equipped. Please check the ${item.name} card for why.`);
         const incompatibleMessage = createIncompatibleItemMessageBox(item);
         element.after(incompatibleMessage);
         return 'incompatible';
@@ -631,16 +632,21 @@ function checkItemsCompatibility(characterId, itemsByName) {
             const element = document.getElementById(`character-${characterId}-${item.id}`);
             element.classList.add('incompatible');
             incompatibleItems.push(item);
-            const incompatibleMessage = createIncompatibleItemMessageBox(item);
-            element.after(incompatibleMessage);
+            element.setAttribute('data-hover', `${item.name} can't be equipped. Please check the ${item.name} card for why.`);
+            // const incompatibleMessage = createIncompatibleItemMessageBox(item);
+            // element.after(incompatibleMessage);
         }
     })
 }
 
 function createCharacterItemsList(nodeList) {
-    const characterList = [];
-    nodeList.forEach(li => characterList.push((li.textContent).slice(0,-1)));
-    return characterList;
+    const characterItems = [];
+    nodeList.forEach(li => {
+        const itemId = li.dataset.characterItemId;
+        const foundItem = findItemWithId(itemId);
+        characterItems.push(foundItem);
+    });
+    return characterItems;
 }
 
 function createEquipOrUnequipItemBtn(characterId, item) {
@@ -739,8 +745,8 @@ function createIncompatibleItemMessageBox(item) {
     messageBox.setAttribute('class', 'incompatible-message');
     messageBox.setAttribute('class', 'hide');
 
-    const message = document.createElement('p');
-    message.textContent = `${item.name} can't be equipped. Please read the ${item.name} card for why.`;
+    const message = document.createElement('span');
+    message.textContent = `${item.name} can't be equipped. Please check the ${item.name} card for why.`;
     
     messageBox.appendChild(message);
 

--- a/data.js
+++ b/data.js
@@ -280,7 +280,7 @@ const items = [
         image: 'item-longsword-132x100.png',
         imageDescription: 'A sword lying in a field next to a sheath',
         equippedLocation: 'right-hand',
-        incompatibilities: 'wizard',
+        incompatibilities: ['wizard'],
         modifiers: {
             attackDice: 3
         }

--- a/styles.css
+++ b/styles.css
@@ -233,7 +233,16 @@ header ul {
 }
 
 .incompatible {
-    cursor: not-allowed;
+    /* cursor: not-allowed; */
+    color: silver;
+}
+
+.incompatible:hover {
+    color: maroon;
+}
+
+.incompatible:hover + .hide {
+    display: block;
 }
 
 .item-image {

--- a/styles.css
+++ b/styles.css
@@ -208,6 +208,7 @@ header ul {
 .weapons-armor-items-container {
     display: flex;
     justify-content: space-around;
+    position: relative;
 }
 
 .weapons-armor-items-header {
@@ -233,16 +234,47 @@ header ul {
 }
 
 .incompatible {
-    /* cursor: not-allowed; */
     color: silver;
+    /* position: relative; */
 }
 
-.incompatible:hover {
-    color: maroon;
+/* .incompatible::before {
+    content: attr(data-hover);
+    visibility: hidden;
+    opacity: 0;
+    background-color: black;
+    color: orange;
+    border: solid 1px silver;
+    border-radius: 8%;
+    transition: opacity 1s ease-in-out 1s;
+    
+    position: absolute;
+    z-index: 1;
+    top: 110%;
+}
+
+.incompatible:hover::before {
+    visibility: visible;
+    opacity: 1;
+} */
+
+.hide {
+    visibility: hidden;
+    opacity: 0;
+    background: black;
+    color: orange;
+    border: 1px solid silver;
+    border-radius: 10px;
+    padding: 2px;
+    transition: opacity 1s ease-in-out 1s;
+
+    position: absolute;
+    z-index: 1;
 }
 
 .incompatible:hover + .hide {
-    display: block;
+    visibility: visible;
+    opacity: 1;
 }
 
 .item-image {
@@ -374,9 +406,9 @@ dialog > fieldset {
     font-weight: 600;
 }
 
-.hide {
+/* .hide {
     display: none;
-}
+} */
 
 .items-card-container {
     width: 100%;


### PR DESCRIPTION
Grey out items that are incompatible with the character type or equipped items. User can hover over the incompatible item and a message will display informing them the item is incompatible with either the character type or equipped items, and to check the item card for details. Incompatibility is removed when items are unequipped that are causing the incompatibility.